### PR TITLE
bugfix(vite-react-plugin): update vite react plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "plugin:promise/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:jest/recommended",
     "plugin:jest-dom/recommended",

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
 module.exports = {
+  base: './',
   stories: [
     '../src/**/*.stories.mdx',
     '../src/**/*.stories.@(js|jsx|ts|tsx)'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6182,27 +6182,6 @@
         }
       }
     },
-    "@vitejs/plugin-react-refresh": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-refresh/-/plugin-react-refresh-1.3.6.tgz",
-      "integrity": "sha512-iNR/UqhUOmFFxiezt0em9CgmiJBdWR+5jGxB2FihaoJfqGt76kiwaKoVOJVU5NYcDWMdN06LbyN2VIGIoYdsEA==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.14.8",
-        "@babel/plugin-transform-react-jsx-self": "^7.14.5",
-        "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-        "@rollup/pluginutils": "^4.1.1",
-        "react-refresh": "^0.10.0"
-      },
-      "dependencies": {
-        "react-refresh": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
-          "integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
-          "dev": true
-        }
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && npm run build:types",
-    "build:types": "tsc src/index.ts --declaration --emitDeclarationOnly --jsx react --esModuleInterop --outDir dist",
+    "build:types": "tsc src/index.ts --declaration --emitDeclarationOnly --jsx react-jsx --esModuleInterop --outDir dist",
     "serve": "vite preview",
     "test": "jest --coverage",
     "test-local": "jest --watch",
@@ -73,7 +73,7 @@
     "@types/react-dom": "17.0.9",
     "@typescript-eslint/eslint-plugin": "4.32.0",
     "@typescript-eslint/parser": "4.32.0",
-    "@vitejs/plugin-react-refresh": "1.3.6",
+    "@vitejs/plugin-react": "1.0.1",
     "babel-eslint": "10.1.0",
     "babel-loader": "8.2.2",
     "eslint": "7.32.0",

--- a/src/Playground.tsx
+++ b/src/Playground.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { HelloWorld } from './components'
 
 export function Playground(): JSX.Element {

--- a/src/components/HelloWord/HelloWorld.stories.tsx
+++ b/src/components/HelloWord/HelloWorld.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { HelloWorld } from './HelloWorld'

--- a/src/components/HelloWord/HelloWorld.test.tsx
+++ b/src/components/HelloWord/HelloWorld.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import { HelloWorld } from './HelloWorld'
 

--- a/src/components/HelloWord/HelloWorld.tsx
+++ b/src/components/HelloWord/HelloWorld.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 interface HelloWorldProps {
   name: string
 }

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
 import { Link, LinkProps } from './Link'

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Link } from './Link'
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 export interface LinkProps extends React.HTMLAttributes<HTMLAnchorElement> {
   /** Provides a text to the anchor */
   children?: React.ReactChild

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
-import { Playground } from './Playground'
 import React from 'react'
 import ReactDOM from 'react-dom'
+
+import { Playground } from './Playground'
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/stories/Button/Button.stories.tsx
+++ b/src/stories/Button/Button.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Button } from './Button'
@@ -10,6 +9,7 @@ const Story: ComponentMeta<typeof Button> = {
     backgroundColor: { control: 'color' },
   },
 }
+
 export default Story
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />

--- a/src/stories/Button/Button.tsx
+++ b/src/stories/Button/Button.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import './button.css'
 
 export interface ButtonProps {

--- a/src/stories/Header/Header.stories.tsx
+++ b/src/stories/Header/Header.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Header } from './Header'

--- a/src/stories/Header/Header.tsx
+++ b/src/stories/Header/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Button } from '../Button/Button'
 import './header.css'
 

--- a/src/stories/Page/Page.stories.tsx
+++ b/src/stories/Page/Page.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Page } from './Page'

--- a/src/stories/Page/Page.tsx
+++ b/src/stories/Page/Page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Header } from '../Header/Header'
 import './page.css'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
-    // "skipLibCheck": true,
     "skipLibCheck": false,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
@@ -15,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'vite'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [reactRefresh()],
+  plugins: [react()],
   build: {
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
Se hace un cambio de nombre del plugin de vite desde @vitejs/plugin-react-refresh a @vitejs/plugin-react y agrupan las siguientes funcionalidades: 

- enable Fast Refresh in development
- use the automatic JSX runtime
- avoid manual import React in .jsx and .tsx modules
- dedupe the react and react-dom packages
- use custom Babel plugins/presets
