### PR TITLE
chore(tsconfig): skip node_modules lib types check

### DIFF
--- a/src/atoms/Colors/Colors.tsx
+++ b/src/atoms/Colors/Colors.tsx
@@ -3,8 +3,10 @@ import { SimpleGrid, Box, BoxProps } from '@chakra-ui/react'
 import { colors } from '../../theme/colors'
 import { Color } from './Color'
 
+type ColorsType = keyof typeof colors
+
 export interface ColorsProps extends BoxProps {
-  type: 'main' | 'alert' | 'icon' | 'neutral'
+  type: ColorsType
 }
 
 export function Colors({ type, ...styles }: ColorsProps): JSX.Element {
@@ -12,7 +14,13 @@ export function Colors({ type, ...styles }: ColorsProps): JSX.Element {
     <Box {...styles}>
       <SimpleGrid columns={6} spacing={5} minChildWidth="8rem">
         {Object.keys(colors[type]).map((color: string, index) => (
-          <Color key={index} type={type} color={color} hexa={colors[type][color]} />
+          <Color
+            key={index}
+            type={type}
+            color={color}
+            // @ts-expect-error
+            hexa={colors[type][color]}
+          />
         ))}
       </SimpleGrid>
     </Box>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
Se elimina el type checking de los nodu_modules 