### PR TITLE
fix(semanticrelease): add version to semantic-release package for deploy task

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build library
         run: npm run build
       - name: Release version  
-        run: npx semantic-release
+        run: npx semantic-release@17
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Agrego version del paquete semantic-release porque las nuevas versiones no soportan node 12, para la tarea de release.