### PR TITLE
fix(PDYE-1395): permisos de escritura release

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,6 +35,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write 
+      issues: write 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Se agrega permiso se escritura al release en el archivo de workflow para permitir que se haga el release automático bajo nueva configuración de seguridad de github.