### PR TITLE
fix(calendar-dropdown): deshabilitamos click en eventos

### DIFF
--- a/src/organisms/Calendar/Dropdown/CalendarDropdown/Components/EventsGroup.test.tsx
+++ b/src/organisms/Calendar/Dropdown/CalendarDropdown/Components/EventsGroup.test.tsx
@@ -53,7 +53,7 @@ describe('EventsGroup', () => {
     expect(onClickEvent).not.toHaveBeenCalled()
   })
 
-  it('calls onClickEvent when event has url', async () => {
+  it('does not call onClickEvent when event has url', async () => {
     const user = userEvent.setup()
     const onClickEvent = jest.fn()
     const event = { ...baseEvent, url: 'https://example.com/evaluation-2' }
@@ -62,7 +62,7 @@ describe('EventsGroup', () => {
 
     await user.click(screen.getByText('Se habilita para responder “Evaluación 2”'))
 
-    expect(onClickEvent).toHaveBeenCalledWith(event)
+    expect(onClickEvent).not.toHaveBeenCalled()
   })
 
   it('renders headquarters address for cpr events', () => {

--- a/src/organisms/Calendar/Dropdown/CalendarDropdown/Components/EventsGroup.tsx
+++ b/src/organisms/Calendar/Dropdown/CalendarDropdown/Components/EventsGroup.tsx
@@ -29,6 +29,8 @@ export const EventsGroup = ({
 }: IEventsGroupProps): JSX.Element => {
   if (!events || (events && events.length === 0)) return <></>
 
+  const eventClicksEnabled = false
+
   return (
     <>
       <Box
@@ -53,12 +55,15 @@ export const EventsGroup = ({
               <Box
                 bg={vars('colors-neutral-white') ?? '#FFFFFF'}
                 border="none"
-                cursor={eventOnClick ? 'pointer' : 'default'}
+                cursor={eventClicksEnabled && eventOnClick ? 'pointer' : 'default'}
                 padding="0"
                 key={event.id}
                 _hover={{
                   boxShadow: 'none !important',
-                  cursor: eventOnClick ? 'pointer !important' : 'default !important',
+                  cursor:
+                    eventClicksEnabled && eventOnClick
+                      ? 'pointer !important'
+                      : 'default !important',
                   bg: 'none !important',
                 }}
                 _focus={{

--- a/src/organisms/Calendar/EventsList/EventsList.test.tsx
+++ b/src/organisms/Calendar/EventsList/EventsList.test.tsx
@@ -28,7 +28,7 @@ const renderComponent = (
   )
 
 describe('EventsList', () => {
-  it('calls onClick when the item is clicked', async () => {
+  it('does not call onClick when the item is clicked even with url', async () => {
     const onClick = jest.fn()
     const user = userEvent.setup()
 
@@ -36,7 +36,7 @@ describe('EventsList', () => {
 
     await user.click(screen.getByText('Evento demo'))
 
-    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClick).not.toHaveBeenCalled()
   })
 
   it('does not call onClick when url is not provided', async () => {

--- a/src/organisms/Calendar/EventsList/EventsList.tsx
+++ b/src/organisms/Calendar/EventsList/EventsList.tsx
@@ -48,7 +48,8 @@ export const EventsList = ({
   const hoverBg = vars('colors-neutral-cultured2') ?? '#F8F8F8'
   const hasUrl = Boolean(url)
   const isAvailable = url === undefined ? true : hasUrl
-  const isClickable = Boolean(onClick) && hasUrl
+  const eventClicksEnabled = false
+  const isClickable = eventClicksEnabled && Boolean(onClick) && hasUrl
   const disabledOpacity = isAvailable ? 1 : 0.5
   const isCpr = type === 'cpr'
   const showEventLocation = !isCpr || Boolean(headquartersAddress)


### PR DESCRIPTION
## Descripción

Se deshabilita temporalmente la interacción de click en los eventos del calendario/dropdown, manteniendo la recepción del `onClick` para reactivarlo más adelante.

## Cambios realizados

- Los eventos ya no ejecutan `onClick` aunque reciban callback y tengan `url`.
- El cursor deja de mostrarse como `pointer` en eventos temporalmente no clickeables.

## Tipo de cambio

- [x] Bugfix
- [ ] Feature
- [ ] Breaking change