### PR TITLE
feat(calendar): agrega clase isCourse al texto de curso

### DIFF
--- a/src/organisms/Calendar/EventsList/EventsList.test.tsx
+++ b/src/organisms/Calendar/EventsList/EventsList.test.tsx
@@ -111,4 +111,16 @@ describe('EventsList', () => {
     expect(screen.queryByText('Curso:')).not.toBeInTheDocument()
     expect(screen.getByText('Curso demo')).toBeInTheDocument()
   })
+
+  it('adds isCourse class when course label is shown', () => {
+    renderComponent(undefined, { text: '' })
+
+    expect(screen.getByText('Curso:').parentElement).toHaveClass('isCourse')
+  })
+
+  it('does not add isCourse class when course label is hidden for cv-events', () => {
+    renderComponent(undefined, { text: '', type: 'cv-events' })
+
+    expect(screen.getByText('Curso demo')).not.toHaveClass('isCourse')
+  })
 })

--- a/src/organisms/Calendar/EventsList/EventsList.test.tsx
+++ b/src/organisms/Calendar/EventsList/EventsList.test.tsx
@@ -115,12 +115,12 @@ describe('EventsList', () => {
   it('adds isCourse class when course label is shown', () => {
     renderComponent(undefined, { text: '' })
 
-    expect(screen.getByText('Curso:').parentElement).toHaveClass('isCourse')
+    expect(screen.getByTestId('event-course')).toHaveClass('isCourse')
   })
 
   it('does not add isCourse class when course label is hidden for cv-events', () => {
     renderComponent(undefined, { text: '', type: 'cv-events' })
 
-    expect(screen.getByText('Curso demo')).not.toHaveClass('isCourse')
+    expect(screen.getByTestId('event-course')).not.toHaveClass('isCourse')
   })
 })

--- a/src/organisms/Calendar/EventsList/EventsList.tsx
+++ b/src/organisms/Calendar/EventsList/EventsList.tsx
@@ -140,7 +140,12 @@ export const EventsList = ({
           </Box>
 
           {showCourse && !initOrEnd && (
-            <Box as="span" className={isCourse ? 'isCourse' : undefined} sx={detailTextStyle}>
+            <Box
+              as="span"
+              className={isCourse ? 'isCourse' : undefined}
+              data-testid="event-course"
+              sx={detailTextStyle}
+            >
               {showCourseLabel && <strong>{courseLabel}:</strong>} {courseName}
             </Box>
           )}

--- a/src/organisms/Calendar/EventsList/EventsList.tsx
+++ b/src/organisms/Calendar/EventsList/EventsList.tsx
@@ -43,6 +43,9 @@ export const EventsList = ({
   const hoverBg = vars('colors-neutral-cultured2') ?? '#F8F8F8'
   const isCpr = type === 'cpr'
   const showEventLocation = !isCpr || Boolean(headquartersAddress)
+  const courseLabel = text || 'Curso'
+  const showCourseLabel = type !== 'cv-events'
+  const isCourse = showCourseLabel && courseLabel === 'Curso'
 
   const showEventDuration =
     ['online', 'in-person', 'cpr'].includes(type) && duration !== undefined && duration > 0
@@ -68,6 +71,9 @@ export const EventsList = ({
     display: 'flex',
     gap: '4px',
     lineHeight: 'normal',
+    '&.isCourse': {
+      alignItems: 'self-start',
+    },
   }
 
   const eventIconStyle = {
@@ -134,9 +140,8 @@ export const EventsList = ({
           </Box>
 
           {showCourse && !initOrEnd && (
-            <Box as="span" sx={detailTextStyle}>
-              {type === 'cv-events' ? <></> : <strong>{text ? `${text}:` : 'Curso:'}</strong>}{' '}
-              {courseName}
+            <Box as="span" className={isCourse ? 'isCourse' : undefined} sx={detailTextStyle}>
+              {showCourseLabel && <strong>{courseLabel}:</strong>} {courseName}
             </Box>
           )}
 


### PR DESCRIPTION
## Descripción

Se agrega la clase `isCourse` al contenedor del texto de curso en `EventsList` cuando se muestra el label `Curso:`.

## Cambios realizados

- Se normaliza el label del curso usando `courseLabel`.
- Se evita mostrar el label en eventos `cv-events`, manteniendo el comportamiento existente.
- Se agrega `className="isCourse"` sólo cuando corresponde.
- Se agregan tests para validar cuándo debe y no debe aplicarse la clase.